### PR TITLE
Let subfolder ignore node_modules

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,1 +1,0 @@
-**/node_modules

--- a/backend/.gitignore
+++ b/backend/.gitignore
@@ -1,3 +1,5 @@
+/node_modules
+
 .yarn/*
 !.yarn/patches
 !.yarn/plugins

--- a/frontend/.gitignore
+++ b/frontend/.gitignore
@@ -1,3 +1,5 @@
+/node_modules
+
 .yarn/*
 !.yarn/patches
 !.yarn/plugins


### PR DESCRIPTION
Because tool like prettier will depend on .gitignore in cwd

Moreover, if backend switch to non node js application, ignore node_modules in parent folder may not be meaningful.