### PR TITLE
Refactor route service

### DIFF
--- a/backend/src/app.test.ts
+++ b/backend/src/app.test.ts
@@ -1,8 +1,7 @@
-import { describe, it, expect, beforeEach, beforeAll } from '@jest/globals'
+import { describe, it, expect, beforeEach } from '@jest/globals'
 import request from 'supertest'
 import { ExpressAppInitializer } from './app'
 import { Express } from 'express'
-import { RouteService } from './route/route'
 import { assertErrorResponse } from './test_utils/assert'
 
 interface Duty {
@@ -170,57 +169,4 @@ describe('API', () => {
   async function callDeleteAllDutiesApi() {
     return request(app).delete('/duties')
   }
-})
-
-describe('Async error handling', () => {
-  describe('should handle uncaught promise exception from routeService', () => {
-    let app: Express
-
-    beforeAll(() => {
-      const asyncHandlerThrowError = async () => {
-        throw new Error('Unexpected error')
-      }
-      const errorRouteService = new (class extends RouteService {
-        constructor() {
-          super()
-          this.get('/', asyncHandlerThrowError)
-          this.post('/', asyncHandlerThrowError)
-          this.put('/', asyncHandlerThrowError)
-          this.delete('/', asyncHandlerThrowError)
-          this.patch('/', asyncHandlerThrowError)
-        }
-      })()
-
-      app = ExpressAppInitializer.createNullApp({
-        extraRouteConfigs: [
-          { path: '/error', routeService: errorRouteService },
-        ],
-      })
-    })
-
-    it('get', async () => {
-      const response = await request(app).get('/error')
-      expect(response.status).toBe(500)
-    })
-
-    it('post', async () => {
-      const response = await request(app).post('/error')
-      expect(response.status).toBe(500)
-    })
-
-    it('put', async () => {
-      const response = await request(app).put('/error')
-      expect(response.status).toBe(500)
-    })
-
-    it('delete', async () => {
-      const response = await request(app).delete('/error')
-      expect(response.status).toBe(500)
-    })
-
-    it('patch', async () => {
-      const response = await request(app).patch('/error')
-      expect(response.status).toBe(500)
-    })
-  })
 })

--- a/backend/src/app.test.ts
+++ b/backend/src/app.test.ts
@@ -1,5 +1,5 @@
 import { describe, it, expect, beforeEach, beforeAll } from '@jest/globals'
-import request, { Response } from 'supertest'
+import request from 'supertest'
 import { ExpressAppInitializer } from './app'
 import {
   Express,
@@ -8,21 +8,11 @@ import {
 } from 'express'
 import { RouteService } from './route/route'
 import { RouteErrorHandler } from './route/util'
+import { assertErrorResponse } from './test_utils/assert'
 
 interface Duty {
   id: string
   name: string
-}
-
-function assertErrorResponse(
-  expected: {
-    status: number
-    message: string
-  },
-  actualResponse: Response,
-) {
-  expect(actualResponse.status).toBe(expected.status)
-  expect(actualResponse.body.message).toBe(expected.message)
 }
 
 describe('API', () => {

--- a/backend/src/app.test.ts
+++ b/backend/src/app.test.ts
@@ -1,13 +1,8 @@
 import { describe, it, expect, beforeEach, beforeAll } from '@jest/globals'
 import request from 'supertest'
 import { ExpressAppInitializer } from './app'
-import {
-  Express,
-  Request as ExpressRequest,
-  Response as ExpressResponse,
-} from 'express'
+import { Express } from 'express'
 import { RouteService } from './route/route'
-import { RouteErrorHandler } from './route/util'
 import { assertErrorResponse } from './test_utils/assert'
 
 interface Duty {
@@ -227,94 +222,5 @@ describe('Async error handling', () => {
       const response = await request(app).patch('/error')
       expect(response.status).toBe(500)
     })
-  })
-})
-
-describe('RouteErrorHandler', () => {
-  class CustomError extends Error {}
-  class UnexpectedError extends Error {}
-
-  function addRootGetRoute(
-    handler: (req: ExpressRequest, res: ExpressResponse) => Promise<void>,
-  ) {
-    const routeService = new (class extends RouteService {
-      constructor() {
-        super()
-        this.get('/', handler)
-      }
-    })()
-
-    return ExpressAppInitializer.createNullApp({
-      extraRouteConfigs: [
-        {
-          path: '/',
-          routeService,
-        },
-      ],
-    })
-  }
-
-  it('should return 500 for unexpected error', async () => {
-    const app = addRootGetRoute(async (req, res) => {
-      try {
-        throw new UnexpectedError('Unexpected error')
-      } catch (err) {
-        return new RouteErrorHandler([
-          {
-            statusCode: 401,
-            typeOfError: CustomError,
-          },
-        ]).handle(err, res)
-      }
-    })
-    const response = await request(app).get('/')
-    expect(response.status).toBe(500)
-  })
-
-  it('should return templated response for expected error', async () => {
-    const app = addRootGetRoute(async (req, res) => {
-      try {
-        throw new CustomError('Default message')
-      } catch (err) {
-        return new RouteErrorHandler([
-          {
-            statusCode: 403,
-            typeOfError: CustomError,
-          },
-        ]).handle(err, res)
-      }
-    })
-    const response = await request(app).get('/')
-    assertErrorResponse(
-      {
-        status: 403,
-        message: 'Default message',
-      },
-      response,
-    )
-  })
-
-  it('should custom response contain custom message if template provided it', async () => {
-    const app = addRootGetRoute(async (req, res) => {
-      try {
-        throw new CustomError('Default message')
-      } catch (err) {
-        return new RouteErrorHandler([
-          {
-            statusCode: 402,
-            typeOfError: CustomError,
-            customMessage: 'Custom message',
-          },
-        ]).handle(err, res)
-      }
-    })
-    const response = await request(app).get('/')
-    assertErrorResponse(
-      {
-        status: 402,
-        message: 'Custom message',
-      },
-      response,
-    )
   })
 })

--- a/backend/src/app.ts
+++ b/backend/src/app.ts
@@ -2,12 +2,6 @@ import express, { Express, NextFunction, Request, Response } from 'express'
 import { DutiesRouteService } from './route/duties'
 import morgan from 'morgan'
 import { ApplicationContext } from './context'
-import { RouteService } from './route/route'
-
-export interface RouteConfig {
-  path: string
-  routeService: RouteService
-}
 
 export class ExpressAppInitializer {
   private readonly app: Express
@@ -26,16 +20,9 @@ export class ExpressAppInitializer {
    *
    * @param extraRouteConfigs - Additional routes to add to the express app. This is useful for testing purposes.
    */
-  static createNullApp({
-    extraRouteConfigs = [],
-  }: {
-    extraRouteConfigs?: RouteConfig[]
-  } = {}) {
+  static createNullApp() {
     const initializer = new ExpressAppInitializer({
       dutiesRouteService: DutiesRouteService.createNull(),
-    })
-    extraRouteConfigs.forEach((routeConfig) => {
-      initializer.addRoute(routeConfig)
     })
     return initializer.app
   }
@@ -49,20 +36,13 @@ export class ExpressAppInitializer {
 
     this.setPreRoutingMiddlewares()
 
-    this.addRoute({
-      path: '/duties',
-      routeService: dutiesRouteService,
-    })
+    this.app.use('/duties', dutiesRouteService.router)
   }
 
   private setPreRoutingMiddlewares() {
     this.app.use(morgan('tiny'))
     this.app.use(allowCors)
     this.app.use(express.json())
-  }
-
-  private addRoute({ path, routeService }: RouteConfig) {
-    this.app.use(path, routeService.router)
   }
 }
 

--- a/backend/src/app.ts
+++ b/backend/src/app.ts
@@ -21,11 +21,6 @@ export class ExpressAppInitializer {
     return initializer.app
   }
 
-  /**
-   * This method is used for testing purposes only.
-   *
-   * @param extraRouteConfigs - Additional routes to add to the express app. This is useful for testing purposes.
-   */
   static createNullApp() {
     const initializer = new ExpressAppInitializer({
       dutiesRouter: DutiesRouterInitializer.createNullRouter(),

--- a/backend/src/app.ts
+++ b/backend/src/app.ts
@@ -1,5 +1,11 @@
-import express, { Express, NextFunction, Request, Response } from 'express'
-import { DutiesRouteService } from './route/duties'
+import express, {
+  Express,
+  NextFunction,
+  Request,
+  Response,
+  Router,
+} from 'express'
+import { DutiesRouterInitializer } from './route/duties'
 import morgan from 'morgan'
 import { ApplicationContext } from './context'
 
@@ -7,10 +13,10 @@ export class ExpressAppInitializer {
   private readonly app: Express
 
   static async createApp(applicationContext: ApplicationContext) {
-    const dutiesRouteService =
-      await DutiesRouteService.create(applicationContext)
+    const dutiesRouter =
+      await DutiesRouterInitializer.createRouter(applicationContext)
     const initializer = new ExpressAppInitializer({
-      dutiesRouteService,
+      dutiesRouter: dutiesRouter,
     })
     return initializer.app
   }
@@ -22,21 +28,15 @@ export class ExpressAppInitializer {
    */
   static createNullApp() {
     const initializer = new ExpressAppInitializer({
-      dutiesRouteService: DutiesRouteService.createNull(),
+      dutiesRouter: DutiesRouterInitializer.createNullRouter(),
     })
     return initializer.app
   }
 
-  private constructor({
-    dutiesRouteService,
-  }: {
-    dutiesRouteService: DutiesRouteService
-  }) {
+  private constructor({ dutiesRouter }: { dutiesRouter: Router }) {
     this.app = express()
-
     this.setPreRoutingMiddlewares()
-
-    this.app.use('/duties', dutiesRouteService.router)
+    this.app.use('/duties', dutiesRouter)
   }
 
   private setPreRoutingMiddlewares() {

--- a/backend/src/route/duties.ts
+++ b/backend/src/route/duties.ts
@@ -4,12 +4,15 @@ import {
   InMemoryDutyRepository,
   PostgresDutyRepository,
 } from '../repositories/duty'
-import { RouteService } from './route'
 import { Duty } from '../models/duty'
 import { ApplicationContext } from '../context'
 import { RouteErrorHandler } from './util'
+import { createRouter } from './route'
+import { Router } from 'express'
 
-export class DutiesRouteService extends RouteService {
+export class DutiesRouteService {
+  router: Router
+
   private dutyRepository: DutyRepository
 
   static async create(applicationContext: ApplicationContext) {
@@ -26,14 +29,37 @@ export class DutiesRouteService extends RouteService {
   }
 
   private constructor({ dutyRepository }: { dutyRepository: DutyRepository }) {
-    super()
     this.dutyRepository = dutyRepository
 
-    this.post('/', this.createDuty)
-    this.get('/', this.listDuties)
-    this.delete('/', this.deleteAllDuties)
-    this.put('/:id', this.updateDuty)
-    this.delete('/:id', this.deleteDuty)
+    const router = createRouter([
+      {
+        path: '/',
+        method: 'post',
+        handler: this.createDuty,
+      },
+      {
+        path: '/',
+        method: 'get',
+        handler: this.listDuties,
+      },
+      {
+        path: '/',
+        method: 'delete',
+        handler: this.deleteAllDuties,
+      },
+      {
+        path: '/:id',
+        method: 'put',
+        handler: this.updateDuty,
+      },
+      {
+        path: '/:id',
+        method: 'delete',
+        handler: this.deleteDuty,
+      },
+    ])
+
+    this.router = router
   }
 
   private createDuty = async (req: Request, res: Response) => {

--- a/backend/src/route/duties.ts
+++ b/backend/src/route/duties.ts
@@ -10,22 +10,22 @@ import { RouteErrorHandler } from './util'
 import { createRouter } from './route'
 import { Router } from 'express'
 
-export class DutiesRouteService {
-  router: Router
+export class DutiesRouterInitializer {
+  private router: Router
 
   private dutyRepository: DutyRepository
 
-  static async create(applicationContext: ApplicationContext) {
+  static async createRouter(applicationContext: ApplicationContext) {
     const dutyRepository = await PostgresDutyRepository.create(
       applicationContext.postgresContext,
     )
-    return new DutiesRouteService({ dutyRepository })
+    return new DutiesRouterInitializer({ dutyRepository }).router
   }
 
-  static createNull() {
-    return new DutiesRouteService({
+  static createNullRouter() {
+    return new DutiesRouterInitializer({
       dutyRepository: new InMemoryDutyRepository(),
-    })
+    }).router
   }
 
   private constructor({ dutyRepository }: { dutyRepository: DutyRepository }) {

--- a/backend/src/route/route.test.ts
+++ b/backend/src/route/route.test.ts
@@ -1,0 +1,71 @@
+import { describe, it, expect, beforeAll } from '@jest/globals'
+import express, { Express } from 'express'
+import request from 'supertest'
+import { createRouter } from './route'
+
+describe('createRouter', () => {
+  describe('should handle uncaught promise exception from handler', () => {
+    let app: Express
+
+    beforeAll(() => {
+      const asyncHandlerThrowError = async () => {
+        throw new Error('Unexpected error')
+      }
+      const router = createRouter([
+        {
+          path: '/',
+          method: 'get',
+          handler: asyncHandlerThrowError,
+        },
+        {
+          path: '/',
+          method: 'post',
+          handler: asyncHandlerThrowError,
+        },
+        {
+          path: '/',
+          method: 'put',
+          handler: asyncHandlerThrowError,
+        },
+        {
+          path: '/',
+          method: 'delete',
+          handler: asyncHandlerThrowError,
+        },
+        {
+          path: '/',
+          method: 'patch',
+          handler: asyncHandlerThrowError,
+        },
+      ])
+
+      app = express()
+      app.use('/error', router)
+    })
+
+    it('get', async () => {
+      const response = await request(app).get('/error')
+      expect(response.status).toBe(500)
+    })
+
+    it('post', async () => {
+      const response = await request(app).post('/error')
+      expect(response.status).toBe(500)
+    })
+
+    it('put', async () => {
+      const response = await request(app).put('/error')
+      expect(response.status).toBe(500)
+    })
+
+    it('delete', async () => {
+      const response = await request(app).delete('/error')
+      expect(response.status).toBe(500)
+    })
+
+    it('patch', async () => {
+      const response = await request(app).patch('/error')
+      expect(response.status).toBe(500)
+    })
+  })
+})

--- a/backend/src/route/route.ts
+++ b/backend/src/route/route.ts
@@ -45,3 +45,29 @@ export abstract class RouteService {
     }
   }
 }
+
+export interface RouteConfig {
+  path: string
+  method: 'get' | 'post' | 'put' | 'patch' | 'delete'
+  handler: (req: Request, res: Response) => void
+}
+
+export function createRouter(routeConfigs: RouteConfig[]): Router {
+  const router = Router()
+  routeConfigs.forEach((routeConfig) => {
+    router[routeConfig.method](routeConfig.path, wrapper(routeConfig.handler))
+  })
+  return router
+}
+
+function wrapper(
+  handler: (req: Request, res: Response) => void,
+): (req: Request, res: Response, next: NextFunction) => void {
+  return async (req: Request, res: Response, next: NextFunction) => {
+    try {
+      await handler(req, res)
+    } catch (error) {
+      next(error)
+    }
+  }
+}

--- a/backend/src/route/route.ts
+++ b/backend/src/route/route.ts
@@ -1,51 +1,5 @@
 import { Router, Request, Response, NextFunction } from 'express'
 
-export abstract class RouteService {
-  readonly router: Router
-
-  constructor() {
-    this.router = Router()
-  }
-
-  protected post(path: string, handler: (req: Request, res: Response) => void) {
-    this.router.post(path, this.wrapper(handler))
-  }
-
-  protected get(path: string, handler: (req: Request, res: Response) => void) {
-    this.router.get(path, this.wrapper(handler))
-  }
-
-  protected put(path: string, handler: (req: Request, res: Response) => void) {
-    this.router.put(path, this.wrapper(handler))
-  }
-
-  protected patch(
-    path: string,
-    handler: (req: Request, res: Response) => void,
-  ) {
-    this.router.patch(path, this.wrapper(handler))
-  }
-
-  protected delete(
-    path: string,
-    handler: (req: Request, res: Response) => void,
-  ) {
-    this.router.delete(path, this.wrapper(handler))
-  }
-
-  private wrapper(
-    handler: (req: Request, res: Response) => void,
-  ): (req: Request, res: Response, next: NextFunction) => void {
-    return async (req: Request, res: Response, next: NextFunction) => {
-      try {
-        await handler(req, res)
-      } catch (error) {
-        next(error)
-      }
-    }
-  }
-}
-
 export interface RouteConfig {
   path: string
   method: 'get' | 'post' | 'put' | 'patch' | 'delete'

--- a/backend/src/route/route.ts
+++ b/backend/src/route/route.ts
@@ -6,6 +6,10 @@ export interface RouteConfig {
   handler: (req: Request, res: Response) => void
 }
 
+/**
+ * Aim of this function is to create a router that wrapped handlers with async error handling support.
+ * Original express router does not support async error handling.
+ */
 export function createRouter(routeConfigs: RouteConfig[]): Router {
   const router = Router()
   routeConfigs.forEach((routeConfig) => {

--- a/backend/src/route/util.test.ts
+++ b/backend/src/route/util.test.ts
@@ -1,0 +1,92 @@
+import express, {
+  Request as ExpressRequest,
+  Response as ExpressResponse,
+} from 'express'
+import request from 'supertest'
+import { describe, it, expect } from '@jest/globals'
+import { createRouter } from './route'
+import { RouteErrorHandler } from './util'
+import { assertErrorResponse } from '../test_utils/assert'
+
+describe('RouteErrorHandler', () => {
+  class CustomError extends Error {}
+  class UnexpectedError extends Error {}
+
+  function newExpressApp(
+    handlerOfRootGetRoute: (
+      req: ExpressRequest,
+      res: ExpressResponse,
+    ) => Promise<void>,
+  ) {
+    const app = express()
+    const router = createRouter([
+      { path: '/', method: 'get', handler: handlerOfRootGetRoute },
+    ])
+    app.use(router)
+    return app
+  }
+
+  it('should return 500 for unexpected error', async () => {
+    const app = newExpressApp(async (req, res) => {
+      try {
+        throw new UnexpectedError('Unexpected error')
+      } catch (err) {
+        return new RouteErrorHandler([
+          {
+            statusCode: 401,
+            typeOfError: CustomError,
+          },
+        ]).handle(err, res)
+      }
+    })
+    const response = await request(app).get('/')
+    expect(response.status).toBe(500)
+  })
+
+  it('should return templated response for expected error', async () => {
+    const app = newExpressApp(async (req, res) => {
+      try {
+        throw new CustomError('Default message')
+      } catch (err) {
+        return new RouteErrorHandler([
+          {
+            statusCode: 403,
+            typeOfError: CustomError,
+          },
+        ]).handle(err, res)
+      }
+    })
+    const response = await request(app).get('/')
+    assertErrorResponse(
+      {
+        status: 403,
+        message: 'Default message',
+      },
+      response,
+    )
+  })
+
+  it('should custom response contain custom message if template provided it', async () => {
+    const app = newExpressApp(async (req, res) => {
+      try {
+        throw new CustomError('Default message')
+      } catch (err) {
+        return new RouteErrorHandler([
+          {
+            statusCode: 402,
+            typeOfError: CustomError,
+            customMessage: 'Custom message',
+          },
+        ]).handle(err, res)
+      }
+    })
+    const response = await request(app).get('/')
+    assertErrorResponse(
+      {
+        status: 402,
+        message: 'Custom message',
+      },
+      response,
+    )
+  })
+})

--- a/backend/src/route/util.ts
+++ b/backend/src/route/util.ts
@@ -7,7 +7,6 @@ export interface RouteErrorTemplate {
   customMessage?: string
 }
 
-// This class is tested in a test suite of app.test.ts
 export class RouteErrorHandler {
   static defaultRouteErrorTemplates: ReadonlyArray<RouteErrorTemplate> = [
     {

--- a/backend/src/test_utils/assert.ts
+++ b/backend/src/test_utils/assert.ts
@@ -1,0 +1,13 @@
+import { expect } from '@jest/globals'
+import { Response } from 'supertest'
+
+export function assertErrorResponse(
+  expected: {
+    status: number
+    message: string
+  },
+  actualResponse: Response,
+) {
+  expect(actualResponse.status).toBe(expected.status)
+  expect(actualResponse.body.message).toBe(expected.message)
+}


### PR DESCRIPTION
1. Pure function to create router wrapped with async error handling support instead of relying  on inheritance
2. Change the static method in DutiesRouteService to create router directly
3. Move tests of error handling in app.test.ts to separate files